### PR TITLE
update internal OO design 

### DIFF
--- a/jquery.soap.js
+++ b/jquery.soap.js
@@ -15,7 +15,7 @@ SOAPResponse.toJSON() depends on jQuery.xml2json.js
 Authors / History
 -----------------
 
-2013-03
+2013-03 >> update internal OO structure, enable XML & object input as well as JSON
 Zach Shelton == zachofalltrades.net  
 https://github.com/zachofalltrades/jquery.soap
 


### PR DESCRIPTION
The update is not quite a drop-in replacement. The return value from the $.soap() will be a SOAPResponse object. This object has toXML, toJSON, and toString methods -- meaning that the 'returnJSON' input parameter is no longer required (or used). It is also now possible to use XML (dom), xml (string), or JSON as the 'params' element when the options are passed in.
