### PR TITLE
fixes doedje/jquery.soap/40

### DIFF
--- a/jquery.soap.js
+++ b/jquery.soap.js
@@ -374,7 +374,7 @@ https://github.com/doedje/jquery.soap/blob/1.3.6/README.md
 		},
 		SOAP12: {
 			type: 'application/soap+xml',
-			namespaceURL: 'http://www.w3.org/2003/05/soap-envelope/'
+			namespaceURL: 'http://www.w3.org/2003/05/soap-envelope'
 		},
 		processData: function(options) {
 			var soapObject;


### PR DESCRIPTION
Remove trailing white space on SOAP 1.2 namespace URL.
