### PR TITLE
Feature remove for in loop in json2soap

### DIFF
--- a/jquery.soap.js
+++ b/jquery.soap.js
@@ -333,7 +333,7 @@ https://github.com/doedje/jquery.soap/blob/1.3.10/README.md
 			for (var attr in this.attributes) {
 				if (typeof(this.attributes[attr]) === 'string') {
 					out.push(' ' + attr + '="' + this.attributes[attr] + '"');
-                }
+				}
 			}
 			out.push('>');
 			//Node children
@@ -439,7 +439,7 @@ https://github.com/doedje/jquery.soap/blob/1.3.10/README.md
 					for(var i = 0; i < params.length; i++) {
 						childObject = this.json2soap(name, params[i], prefix, parentNode);
 						parentNode.appendChild(childObject);
-                    }
+					}
 				} else if (params.constructor.toString().indexOf("String") > -1) { // type is string
 					// handle String objects as string primitive value
 					soapObject = new SOAPObject(prefix+name);


### PR DESCRIPTION
The for in loops where adding method definitions to the generated xml string which is obviously invalid xml. I noticed this when trying to add the data as JSON with an array of objects. Happy to provide an example if required...
