### PR TITLE
Fix namespace and type for nil attribute

### DIFF
--- a/jquery.soap.js
+++ b/jquery.soap.js
@@ -209,8 +209,12 @@ https://github.com/doedje/jquery.soap/blob/1.4.3/README.md
 			if (!soapEnv.attr('xmlns:' + this.prefix)) {
 				soapEnv.addNamespace(this.prefix, this.soapConfig.namespaceURL);
 			}
-			// maybe add xsi here?
-			// xsi="http://www.w3.org/2001/XMLSchema-instance
+			if (!soapEnv.attr('xmlns:xsi')) {
+				soapEnv.addNamespace('xsi', 'http://www.w3.org/2001/XMLSchema-instance');
+			}
+			if (!soapEnv.attr('xmlns:xsd')) {
+				soapEnv.addNamespace('xsd', 'http://www.w3.org/2001/XMLSchema');
+			}
 			return '<?xml version="1.0" encoding="UTF-8"?>' + soapEnv.toString();
 		},
 		send: function(options) {
@@ -273,7 +277,7 @@ https://github.com/doedje/jquery.soap/blob/1.4.3/README.md
 		};
 		this.val = function(value) {
 			if (value === undefined) {
-				if (this.attr('nil') === 'true') {
+				if (this.attr('xsi:nil') === 'true') {
 					return null;
 				} else {
 					return this.value;
@@ -282,7 +286,7 @@ https://github.com/doedje/jquery.soap/blob/1.4.3/README.md
 				this.value = value;
 				return this;
 			} else {
-				this.attr("nil","true");
+				this.attr("xsi:nil","true");
 				return this;
 			}
 		};
@@ -445,7 +449,7 @@ https://github.com/doedje/jquery.soap/blob/1.4.3/README.md
 			var childObject;
 			if (params === null) {
 				soapObject = new SOAPObject(prefix+name);
-				soapObject.attr('nil', true);
+				soapObject.attr('xsi:nil', 'true');
 			} else if (typeof params == 'object') {
 				// added by DT - check if object is in fact an Array and treat accordingly
 				if(params.constructor.toString().indexOf("Array") > -1) { // type is array


### PR DESCRIPTION
This is my first time using soap, so this change may be wrong. I need to include a null value in the soap request. I had two issues. First, the 'nil' attribute wasn't being added at all. If I change the type of the 'true' from boolean to string then it is added. However, the server ignored the 'nil' attribute. To get it to work I had to qualify it with the xsi namespace.

I've added the xsi definition at the same location as the nil attribute. I did it this way because it matches the behaviour of the existing Silverlight client for this service.

An alternative way of fixing this would be to define the xsi namespace in the envelope, and there's a comment there about doing that. I can fix it that way if you prefer. If so, should this be a config option?

There's also some nil handling in the SOAPObject handler. Should the xsi namespace be specified there too? I see in the git history that it used to be, but that was removed in 2b68f65a63ce183beaa53a965b7a0bdc23f34267.
