### PR TITLE
XHR for progress support may break IE8/IE9 cross-domain requests

### DIFF
--- a/jquery.soap.js
+++ b/jquery.soap.js
@@ -276,6 +276,8 @@ https://github.com/doedje/jquery.soap/blob/1.6.5/README.md
 				contentType: contentType + "; charset=UTF-8",
 				// second attempt to get some progres info (but still a no go)
 				// I still keep this in tho, we might see it working one day when browsers mature...
+				/*
+				//WRT issue #80 (https://github.com/doedje/jquery.soap/issues/80) commenting out the xhr function below for IE8 and IE9 compatability. Issue exists when used alongside any script that modifies the XMLHttpRequest object like, for example, the xdomain or xhook libraries. This could be explicitly enabled by users on a per-case basis if it is mentioned somewhere in the readme.md file. 
 				xhr: function() {
 					var xhr = new window.XMLHttpRequest();
 					xhr.upload.addEventListener("progress", function(evt) {
@@ -293,6 +295,7 @@ https://github.com/doedje/jquery.soap/blob/1.6.5/README.md
 
 					return xhr;
 				},
+				*/
 				beforeSend: function() {
 					if ($.isFunction(options.beforeSend)) {
 						return options.beforeSend.call(options.context, self);


### PR DESCRIPTION
WRT [issue #80](https://github.com/doedje/jquery.soap/issues/80) commenting out the `xhr` function for IE8 and IE9 compatability. Issue exists when used alongside any script that modifies the `XMLHttpRequest` object like, for example, the [xdomain](https://github.com/jpillora/xdomain/) or [xhook](https://github.com/jpillora/xhook/) libraries. This could be explicitly enabled by users on a per-case basis if it is mentioned somewhere in the readme.md file.

As per [one statistic](https://www.netmarketshare.com/browser-market-share.aspx?qprid=2&qpcustomd=0), as of today, IE8 and IE9 have a cumulative market-share of around 20%, a not-insignificant figure. 

However, the issue/fix could be considered an edge case as not all users may have the issue: they may not be using a script that modifies the XMLHttpRequest object. The benefit in having the `xhr` function in-place and ready for the `progress` event support may outweigh having to have it enabled by hand (by removing the comments after reading the readme.md). On the other hand soap calls to remote URLs are a high percentage as well.