### PR TITLE
Encode attribute values

### DIFF
--- a/jquery.soap.js
+++ b/jquery.soap.js
@@ -415,7 +415,10 @@ https://github.com/doedje/jquery.soap/blob/1.6.10/README.md
 			//Node Attributes
 			for (var attr in this.attributes) {
 				if (typeof(this.attributes[attr]) === 'string') {
-					out.push(' ' + attr + '="' + this.attributes[attr] + '"');
+					encodedValue = this.attributes[attr].replace(/[<>&"']/g, function (ch) {
+						return xmlCharMap[ch];
+					});
+					out.push(' ' + attr + '="' + encodedValue + '"');
 				}
 			}
 			out.push('>');


### PR DESCRIPTION
This one is related to #59. Attribute values aren't encoded yet and can lead to invalid XML.