### PR TITLE
Account for null response

### DIFF
--- a/jquery.soap.js
+++ b/jquery.soap.js
@@ -467,7 +467,7 @@ https://github.com/doedje/jquery.soap/blob/1.7.1/README.md
 		this.headers = xhr.getAllResponseHeaders().split('\n');
 		this.httpCode = xhr.status;
 		this.httpText = xhr.statusText;
-		this.content = (xhr.responseXML === undefined) ? xhr.responseText : xhr.responseXML;
+		this.content = (xhr.responseXML === undefined || xhr.responseXML === null) ? xhr.responseText : xhr.responseXML;
 		this.toString = function(){
 			if (typeof this.content === 'string') {
 				return this.content;


### PR DESCRIPTION
Some webservices only allow a request and do not provide a response (or possibly just a specific HTTP 2xx success code). I noticed that (in Chrome and Safari) the script runs into an error in such cases, because the xhr.responseXML property is null.

> Uncaught Error: Unexpected Content: null
>     at SOAPResponse.toString (VM166 jquery.soap.js?_=1507333726234:478)

See [this jsFiddle](https://jsfiddle.net/oneton/dxfz4bfc/1/). It calls a static (non SOAP) PHP script that simulates the behaviour by just returning HTTP status code 202. When using the fiddle as-is (jquery.soap version 1.7.1), the JS browser console shows an error when running the fiddle. Replace the included script as indicated (add -patched) and the call succeeds.