### PR TITLE
fix license naming expression

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "ecosystem:jquery"
   ],
   "bugs": "https://github.com/doedje/jquery.soap",
-  "license": "GPL-3.0+",
+  "license": "GPL-3.0-or-later",
   "author": {
     "name": "Remy Blom",
     "email": "remy.blom@hku.nl"


### PR DESCRIPTION
Fix the license name so it fullfills the package.json license section (https://docs.npmjs.com/files/package.json#license). Compared to 'GPL-V3+' the term 'GPL-3.0-or-later' is also OSI approved.
The benefit from this change would be that the project can be processed in the webjars building environment. So it becomes also available as an webjar (https://www.webjars.org/).